### PR TITLE
Make $handleName nullable in afterAddHandle plugin

### DIFF
--- a/Plugin/RemoveHandlersPlugin.php
+++ b/Plugin/RemoveHandlersPlugin.php
@@ -24,7 +24,7 @@ class RemoveHandlersPlugin
     public function afterAddHandle(
         ProcessorInterface $subject,
         ProcessorInterface $result,
-        array|string $handleName
+        array|string|null $handleName
     ): ProcessorInterface {
         if (!$this->config->isModuleEnabled()) {
             return $result;


### PR DESCRIPTION
We are running into this error, which is fixed by adding `null` to the type hint.

```
TypeError: Vendic\OptimizeCacheSize\Plugin\RemoveHandlersPlugin::afterAddHandle(): Argument #3 ($handleName) must be of type array|string, null given, called in /data/web/releases/20250401082050/vendor/magento/framework/Interception/Interceptor.php on line 146 and defined in /data/web/releases/20250401082050/vendor/vendic/module-optimize-cache-size/Plugin/RemoveHandlersPlugin.php:24
Stack trace:
#0 /data/web/releases/20250401082050/vendor/magento/framework/Interception/Interceptor.php(146): Vendic\OptimizeCacheSize\Plugin\RemoveHandlersPlugin->afterAddHandle()
#1 /data/web/releases/20250401082050/vendor/magento/framework/Interception/Interceptor.php(153): Hyva\Theme\Framework\View\Model\Layout\Merge\Interceptor->Magento\Framework\Interception\{closure}()
#2 /data/web/releases/20250401082050/generated/code/Hyva/Theme/Framework/View/Model/Layout/Merge/Interceptor.php(23): Hyva\Theme\Framework\View\Model\Layout\Merge\Interceptor->___callPlugins()
#3 /data/web/releases/20250401082050/vendor/magento/framework/Pricing/Render/Layout.php(45): Hyva\Theme\Framework\View\Model\Layout\Merge\Interceptor->addHandle()
#4 /data/web/releases/20250401082050/vendor/magento/framework/Pricing/Render.php(69): Magento\Framework\Pricing\Render\Layout->addHandle()
#5 /data/web/releases/20250401082050/vendor/magento/framework/View/Element/AbstractBlock.php(288): Magento\Framework\Pricing\Render->_prepareLayout()
#6 /data/web/releases/20250401082050/vendor/magento/framework/View/Layout/Generator/Block.php(149): Magento\Framework\View\Element\AbstractBlock->setLayout()
#7 /data/web/releases/20250401082050/vendor/magento/framework/View/Layout/GeneratorPool.php(93): Magento\Framework\View\Layout\Generator\Block->process()
#8 /data/web/releases/20250401082050/vendor/magento/framework/View/Layout.php(365): Magento\Framework\View\Layout\GeneratorPool->process()
#9 /data/web/releases/20250401082050/vendor/magento/framework/Interception/Interceptor.php(58): Magento\Framework\View\Layout->generateElements()
#10 /data/web/releases/20250401082050/vendor/magento/framework/Interception/Interceptor.php(138): Magento\Framework\View\Layout\Interceptor->___callParent()
#11 /data/web/releases/20250401082050/vendor/magento/framework/Interception/Interceptor.php(153): Magento\Framework\View\Layout\Interceptor->Magento\Framework\Interception\{closure}()
#12 /data/web/releases/20250401082050/generated/code/Magento/Framework/View/Layout/Interceptor.php(32): Magento\Framework\View\Layout\Interceptor->___callPlugins()
#13 /data/web/releases/20250401082050/vendor/magento/framework/View/Layout/Builder.php(129): Magento\Framework\View\Layout\Interceptor->generateElements()
#14 /data/web/releases/20250401082050/vendor/magento/framework/View/Page/Builder.php(65): Magento\Framework\View\Layout\Builder->generateLayoutBlocks()
#15 /data/web/releases/20250401082050/vendor/magento/framework/View/Layout/Builder.php(65): Magento\Framework\View\Page\Builder->generateLayoutBlocks()
#16 /data/web/releases/20250401082050/vendor/magento/framework/View/Page/Config.php(227): Magento\Framework\View\Layout\Builder->build()
#17 /data/web/releases/20250401082050/vendor/magento/framework/View/Page/Config.php(591): Magento\Framework\View\Page\Config->build()
#18 /data/web/releases/20250401082050/vendor/magento/framework/View/Page/Config.php(549): Magento\Framework\View\Page\Config->getElementAttribute()
```