### PR TITLE
Added a category id exclusion option in the config

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -15,15 +15,17 @@ class Config
     private const OCS_GENERAL_PRODUCT_ID_PATH = 'optimize_cache_size/general/product_id';
     private const OCS_GENERAL_PRODUCT_SKU_PATH = 'optimize_cache_size/general/product_sku';
     private const OCS_GENERAL_CATEGORY_ID_PATH = 'optimize_cache_size/general/category_id';
+    private const OCS_GENERAL_CATEGORY_ID_EXCLUSION_PATH = 'optimize_cache_size/general/category_id_exclusion';
 
     public function __construct(
         private ScopeConfigInterface $scopeConfig
-    ) {
+    )
+    {
     }
 
     public function isModuleEnabled(int $store = 0): bool
     {
-        return  $this->scopeConfig->isSetFlag(
+        return $this->scopeConfig->isSetFlag(
             self::OCS_GENERAL_IS_ENABLED_PATH,
             ScopeInterface::SCOPE_STORE,
             $store
@@ -32,7 +34,7 @@ class Config
 
     public function isRemoveProductIdHandlers(int $store = 0): bool
     {
-        return  $this->scopeConfig->isSetFlag(
+        return $this->scopeConfig->isSetFlag(
             self::OCS_GENERAL_PRODUCT_ID_PATH,
             ScopeInterface::SCOPE_STORE,
             $store
@@ -41,7 +43,7 @@ class Config
 
     public function isRemoveProductSkuHandlers(int $store = 0): bool
     {
-        return  $this->scopeConfig->isSetFlag(
+        return $this->scopeConfig->isSetFlag(
             self::OCS_GENERAL_PRODUCT_SKU_PATH,
             ScopeInterface::SCOPE_STORE,
             $store
@@ -50,10 +52,19 @@ class Config
 
     public function isRemoveCategoryIdHandlers(int $store = 0): bool
     {
-        return  $this->scopeConfig->isSetFlag(
+        return $this->scopeConfig->isSetFlag(
             self::OCS_GENERAL_CATEGORY_ID_PATH,
             ScopeInterface::SCOPE_STORE,
             $store
         );
+    }
+
+    public function getCategoryIdExclusions(int $store = 0): array
+    {
+        return explode(',', $this->scopeConfig->getValue(
+            self::OCS_GENERAL_CATEGORY_ID_EXCLUSION_PATH,
+            ScopeInterface::SCOPE_STORE,
+            $store
+        ) ?? '');
     }
 }

--- a/Model/Config/Source/CategoryList.php
+++ b/Model/Config/Source/CategoryList.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Vendic\OptimizeCacheSize\Model\Config\Source;
+
+use Magento\Catalog\Model\ResourceModel\Category\CollectionFactory;
+use Magento\Framework\Data\OptionSourceInterface;
+
+class CategoryList implements OptionSourceInterface
+{
+    /**
+     * @var CollectionFactory
+     */
+    private $categoryCollectionFactory;
+
+    public function __construct(
+        CollectionFactory $categoryCollectionFactory
+    ) {
+        $this->categoryCollectionFactory = $categoryCollectionFactory;
+    }
+
+    /**
+     * Return array of ['value' => <category_id>, 'label' => <category_name>]
+     *
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        $collection = $this->categoryCollectionFactory->create();
+        $collection->addAttributeToSelect('name')
+            ->addIsActiveFilter()
+            ->addAttributeToSort('name', 'ASC');
+
+        $options = [];
+        foreach ($collection as $category) {
+            $options[] = [
+                'value' => $category->getId(),
+                'label' => $category->getName()
+            ];
+        }
+
+        return $options;
+    }
+}

--- a/Plugin/RemoveHandlersPlugin.php
+++ b/Plugin/RemoveHandlersPlugin.php
@@ -33,8 +33,14 @@ class RemoveHandlersPlugin
         foreach ($handlers as $handler) {
             if ($this->config->isRemoveCategoryIdHandlers()
                 && str_contains($handler, self::CATEGORY_ID_HANDLER_STRING)) {
-                $result->removeHandle($handler);
-                continue;
+
+                $categoryID = str_replace(self::CATEGORY_ID_HANDLER_STRING, '', $handler);
+                $categoryIdExclusions = $this->config->getCategoryIdExclusions();
+
+                if(!in_array($categoryID, $categoryIdExclusions)){
+                    $result->removeHandle($handler);
+                    continue;
+                }
             }
             if ($this->config->isRemoveProductIdHandlers()
                 && str_contains($handler, self::PRODUCT_ID_HANDLER_STRING)) {

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -48,6 +48,16 @@
                         <field id="optimize_cache_size/general/enabled">1</field>
                     </depends>
                 </field>
+                <field id="category_id_exclusion" translate="label" type="multiselect" sortOrder="40" showInDefault="1"
+                       showInWebsite="1" showInStore="1">
+                    <label>Exclude Category IDs</label>
+                    <source_model>Vendic\OptimizeCacheSize\Model\Config\Source\CategoryList</source_model>
+                    <comment>Select all categories which should keep their id in the cache handle</comment>
+                    <depends>
+                        <field id="optimize_cache_size/general/enabled">1</field>
+                        <field id="optimize_cache_size/general/category_id">1</field>
+                    </depends>
+                </field>
             </group>
         </section>
     </system>


### PR DESCRIPTION
Encountered an issue where removing the category id handler would prevent content widgets specific for a category id would not show up